### PR TITLE
Safety guards for missing or unresolvable preferences during extension startup

### DIFF
--- a/operators/maya_pivot.py
+++ b/operators/maya_pivot.py
@@ -60,6 +60,8 @@ def toggle_deafult_gizmos(context, hide=False):
 
 def should_show_pivot_gizmo(context):
     prefs = get_keyops_prefs()
+    if not prefs:
+        return False
     show_gizmo = prefs.maya_pivot_show_gizmo
     wm = context.window_manager
     if prefs.maya_pivot_experimental:
@@ -127,11 +129,15 @@ class PivotPress(bpy.types.Operator):
     @classmethod
     def poll(cls, context):
         prefs = get_keyops_prefs()
+        if not prefs:
+            return False
         return context.active_object is not None and context.object in context.selected_objects and context.active_object.mode == 'OBJECT' or context.mode == 'EDIT_MESH' and prefs.maya_pivot_experimental
     
     def invoke(self, context, event):
         # if context.mode == 'EDIT_MESH':
         prefs = get_keyops_prefs()
+        if not prefs:
+            return {'FINISHED'}
         pivot_behavior = prefs.maya_pivot_behavior
         if pivot_behavior != 'TOGGLE':          
             wm = context.window_manager
@@ -144,6 +150,8 @@ class PivotPress(bpy.types.Operator):
              
     def execute(self, context):
         prefs =  get_keyops_prefs()
+        if not prefs:
+            return {'FINISHED'}
         pivot_behavior = prefs.maya_pivot_behavior
         show_gizmo = prefs.maya_pivot_show_gizmo
 
@@ -228,7 +236,7 @@ class PivotPress(bpy.types.Operator):
                     toggle_deafult_gizmos(context, hide=False)
 
             elif context.mode == 'EDIT_MESH':
-                if prefs.maya_pivot_in_edit_mode:
+                if prefs and prefs.maya_pivot_in_edit_mode:
                     global current_active_tool
 
                     if self.type == 'PivotPress':

--- a/utils/pref_utils.py
+++ b/utils/pref_utils.py
@@ -12,9 +12,25 @@ def get_is_addon_enabled(addon_name):
 def get_addon_name():
     return base_package
 
+class KeyOpsPrefsMock:
+    def __getattr__(self, name):
+        return False
+
 def get_keyops_prefs():
-    addon_prefs = bpy.context.preferences.addons[base_package]
-    return addon_prefs.preferences
+    if not hasattr(bpy.context, "preferences"):
+        return KeyOpsPrefsMock()
+
+    addons = bpy.context.preferences.addons
+
+    if base_package in addons:
+        return addons[base_package].preferences
+
+    addon_id = base_package.split(".")[-1]
+    for name, addon in addons.items():
+        if name == addon_id or name.endswith(f".{addon_id}"):
+            return addon.preferences
+
+    return KeyOpsPrefsMock()
 
 def get_addon_path(addon_name):
     for addon in bpy.context.preferences.addons:
@@ -23,7 +39,9 @@ def get_addon_path(addon_name):
         
 def get_addon_preferences(addon_name):
     name = get_addon_path(addon_name)
-    return bpy.context.preferences.addons[str(name)]
+    if not name:
+        return KeyOpsPrefsMock()
+    return bpy.context.preferences.addons.get(str(name), KeyOpsPrefsMock())
 
 #The following code is based on the MACHIN3 addon: MACHIN3tools
 #Check out there awesome addons here: https://machin3.io/

--- a/utils/register_extensions.py
+++ b/utils/register_extensions.py
@@ -144,7 +144,8 @@ def enable_extension(self, register, extension):
 def operator(operator_name):
     def decorator(func):
         def wrapper(classlists=[], keylists=[]):
-            if getattr(get_keyops_prefs(), f"enable_{operator_name.lower().replace(' ', '_')}"):
+            prefs = get_keyops_prefs()
+            if prefs and getattr(prefs, f"enable_{operator_name.lower().replace(' ', '_')}", False):
                 operator_class = classesdict[operator_name.upper().replace(' ', '_')]
                 operator_key = keysdict.get(operator_name.upper().replace(' ', '_'), None)
                 classlists.append(operator_class)


### PR DESCRIPTION
Refactor `pref_utils.py` and `register_extensions.py` to handle missing or unresolvable preferences with safety guards to avoid scenarios where the extension won't load at all in Blender v.>5.0.0

Add similar safety guards in `maya_pivot.py` since this was also showing itself to be a source of errors at runtime when attempting to load the extension.